### PR TITLE
Travel national

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.1
+current_version = 0.5.0
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2022-11-24
+### Added
+- two new fields added to the Candidate input. These reflect nationality and passport requirements
+
 ## [0.4.0] - 2022-11-24
 ### Added
 - a new script has been added. This brings the software closer to version 1.0.0. Although it requires a developer to

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -41,6 +41,8 @@ class Candidate(BaseClass):
         no_immigration: StrBool,
         preferred_office_attendance: str,
         skills_seeking: str,
+        british_national: StrBool,
+        has_passport: StrBool,
     ):
         super().__init__(uuid, clearance_held)
         self.can_relocate = json.loads(can_relocate.lower())
@@ -54,6 +56,8 @@ class Candidate(BaseClass):
         self.no_immigration = json.loads(no_immigration.lower())
         self.preferred_office_attendance = preferred_office_attendance
         self.skills_seeking: Sequence[str] = skills_seeking.split(",")
+        self.british_national = json.loads(british_national.lower())
+        self.has_passport = json.loads(has_passport.lower())
 
 
 class Role(BaseClass):
@@ -118,7 +122,7 @@ class Pair:
         if self.role.priority_role:
             self._score += self.scoring_weights["priority"]
 
-    def score_pair(self):
+    def score_pair(self) -> int:
         self._score_location()
         self._score_clearance()
         self._score_department()
@@ -126,6 +130,8 @@ class Pair:
         self._appropriate_for_year_group()
         self._skill_check()
         self._stretch_check()
+        self._score_nationality()
+        self._check_travel()
         return self._score
 
     def _score_location(self):
@@ -141,6 +147,16 @@ class Pair:
 
     def _score_clearance(self):
         self.disqualified = self.candidate.clearance < self.role.clearance
+
+    def _score_nationality(self):
+        self.disqualified = (
+            self.role.nationality_requirement and not self.candidate.british_national
+        )
+
+    def _check_travel(self):
+        self.disqualified = (
+            self.role.travel_requirements and not self.candidate.has_passport
+        )
 
     def _score_department(self):
         if self.role.department not in self.candidate.prior_departments:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fast-stream-22"
-version = "0.4.1"
+version = "0.5.0"
 description = ""
 authors = ["jonathan.kerr <jonathan.kerr@digital.cabinet-office.gov.uk>"]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,8 @@ def random_candidate_dict():
             "no_defence": False,
             "no_immigration": False,
             "preferred_office_attendance": "",
+            "british_national": True,
+            "has_passport": True,
         }
         candidate["prior_departments"] = ",".join(
             random.sample(departments, k=candidate["year_group"] - 1)

--- a/tests/test_read_in.py
+++ b/tests/test_read_in.py
@@ -17,6 +17,8 @@ class TestInstantiation:
             "false",
             "",
             "Policy,Digital,Finance,Operational",
+            "true",
+            "true",
         ]
         candidate = Candidate(*c_data_row)
         assert candidate


### PR DESCRIPTION
This adds two fields to the Candidate input: nationality and passport. On nationality, there are some roles that are reserved to UK nationals. On passport: some roles require the holder to carry out international travel