### PR TITLE
Limit numbers

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.7.1
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.1
+current_version = 0.7.0
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1]
+
+## [0.7.0] - 2022-12-23
+### Added
+- a new object, `Process`, is added. This provides an interface for running multiple rounds of matching
+- a new `Bid` object is added, which contains the bids for candidates
+- We've done this because of a new requirement: often, departments provide more roles than they bid for. Sometimes they
+  provide up to 10% more roles than they can afford. The `Process` object takes a `bids` argument.
+- Bids should be provided as a CSV file. The department names in both the bids file and the roles file _and_ the
+  candidates' previous roles must be the same. This is a fragility in the system I would like to improve in the new year
+
 ## [0.6.1] - 2022-11-29
 ### Changed
 - software now matches 'Remote' and 'Available Nationally' as if it were a first_location preference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.1]
+## [0.7.1] - 2022-12-23
+### Changed
+- the script is updated to print its outputs
+- the matching algorithm is reversed, so that it starts by matching the most junior cohort
 
 ## [0.7.0] - 2022-12-23
 ### Added

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -46,12 +46,12 @@ class Process:
 
     def compute(self):
         """
-        Try to solve each cohort in turn, starting with the most senior. When finished, unmark any roles that were
+        Try to solve each cohort in turn, starting with the most junior. When finished, unmark any roles that were
         rejected, as they may be suitable for the next cohort.
 
         :return:
         """
-        cohorts = sorted(set((bid.cohort for bid in self.bids)), reverse=True)
+        cohorts = sorted(set((bid.cohort for bid in self.bids)), reverse=False)
         for cohort in cohorts:
             if self.match_cohort(cohort):
                 print(f"Successfully matched cohort {cohort}")

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -1,11 +1,161 @@
 from __future__ import annotations
 
+import dataclasses
 import sys
-from typing import Sequence, Union
+from collections import defaultdict
+from typing import (
+    Sequence,
+    Union,
+    TypeVar,
+    Optional,
+)
 from munkres import DISALLOWED, make_cost_matrix, Munkres
 
-from fast_stream_22.matching.models import Candidate, Role, Pair
+from fast_stream_22.matching.models import Candidate, Role, Pair, BaseClass
 import numpy as np
+
+
+@dataclasses.dataclass
+class Bid:
+    cohort: int
+    department: str
+    number: int = 0
+    count: int = 0
+
+    @property
+    def min_number(self):
+        return max([int(0.8 * self.number), self.number - 1, 1])
+
+
+class Process:
+    def __init__(
+        self,
+        all_candidates: Sequence[Candidate],
+        all_roles: Sequence[Role],
+        bids: Sequence[Bid],
+    ):
+        self._all_candidates = all_candidates
+        self.candidate_mapping: dict[str, Candidate] = {
+            c.uid: c for c in all_candidates
+        }
+        self._all_roles = all_roles
+        self.all_roles_mapping: dict[str, Role] = {r.uid: r for r in all_roles}
+        self.bids = bids
+        self.pairings: dict[int, list[tuple[str, str]]] = defaultdict(list)
+        self.max_rounds = 3
+
+    def compute(self):
+        """
+        Try to solve each cohort in turn, starting with the most senior. When finished, unmark any roles that were
+        rejected, as they may be suitable for the next cohort.
+
+        :return:
+        """
+        cohorts = sorted(set((bid.cohort for bid in self.bids)), reverse=True)
+        for cohort in cohorts:
+            if self.match_cohort(cohort):
+                print(f"Successfully matched cohort {cohort}")
+            else:
+                print(f"Could not match cohort {cohort}")
+            self.reset_roles()
+
+    def reset_roles(self):
+        """
+        Mark all roles as matchable
+
+        :return:
+        """
+        for r in self._all_roles:
+            r.no_match = False
+
+    @property
+    def all_candidates(self) -> list[Candidate]:
+        """
+        Get all candidates that haven't been paired
+
+        :return: a list of unpaired candidates
+        """
+        return self.mask_paired(self._all_candidates)
+
+    @property
+    def all_roles(self) -> list[Role]:
+        """
+        Get all the roles that haven't been paired and haven't been marked as 'rejected'
+
+        :return: a list of unpaired, unrejected roles
+        """
+        return sorted(
+            self.mask_paired([r for r in self._all_roles if not r.no_match]),
+            key=lambda role: role.priority_role,
+            reverse=True,
+        )
+
+    Pairable = TypeVar("Pairable", bound=BaseClass)
+
+    @staticmethod
+    def mask_paired(data: Sequence[Pairable]) -> list[Pairable]:
+        """
+        Hide the data that's already been paired
+
+        :param data: a sequence of Pairable objects
+        :return: a list of Pairable objects that haven't yet been paired
+        """
+        return [data_point for data_point in data if not data_point.paired]
+
+    @staticmethod
+    def pair_off(
+        candidates: Sequence[Candidate], roles: Sequence[Role]
+    ) -> list[tuple[str, str]]:
+        """
+        Create a round of Matching, compute it, and return the pairs
+
+        :param candidates: this cohort's candidates
+        :param roles: the potential set of roles
+        :return: a list of paired candidate/role
+        """
+        return Matching(candidates, roles).report_pairs()
+
+    def match_cohort(self, cohort: int, round: int = 0) -> bool:
+        """
+        This method takes a cohort and tries to match the candidates to potential roles. Where matches are made, bids
+        are reduced. This means that once a department has met its quota it no longer gets to put roles in for matching
+
+        :param cohort: the year group we're matching
+        :param round: the number of times we've tried this
+        :return: a boolean signifying if we were successful
+        """
+        cohort_bids: dict[str, Bid] = {
+            bid.department: bid for bid in self.bids if bid.cohort == cohort
+        }
+        if round >= self.max_rounds:
+            return all(
+                map(lambda bid: bid.count >= bid.min_number, cohort_bids.values())
+            )
+        candidates = [c for c in self.all_candidates if c.year_group == cohort]
+        suitable_roles = [
+            role for role in self.all_roles if cohort in role.suitable_year_groups
+        ]
+        shortlisted_roles = []
+        for bid in cohort_bids.values():
+            shortlisted_roles.extend(
+                [role for role in suitable_roles if role.department == bid.department][
+                    : bid.number - bid.count
+                ]
+            )
+        this_round = Matching(candidates, shortlisted_roles)
+        if this_round.reject_impossible_roles():
+            return self.match_cohort(cohort, round)
+        pairs = self.pair_off(candidates, shortlisted_roles)
+        for candidate_id, role_id in pairs:
+            self.candidate_mapping[candidate_id].mark_paired()
+            role = self.all_roles_mapping[role_id]
+            role.mark_paired()
+            cohort_bids[role.department].count += 1
+        self.pairings[cohort].extend(pairs)
+        if len(pairs) == len(candidates):
+            return True
+        else:
+            return self.match_cohort(cohort, round + 1)
 
 
 class Matching:
@@ -46,6 +196,10 @@ class Matching:
         return Munkres().compute(matrix)
 
     def report_pairs(self) -> list[tuple[str, str]]:
+        """
+        :return: Return a list of tuples, representing the candidate-role pairings
+
+        """
         pairs = self._match()
         return [self._convert_pair(p) for p in pairs]
 

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -17,6 +17,20 @@ class Matching:
         ]
         self.score_grid = np.reshape(self.pairs, (len(candidates), len(roles)))
 
+    def reject_impossible_roles(self) -> list[Optional[Role]]:
+        """
+        Identify and reject roles that no candidate can do
+
+        :return: a list of rejected roles
+        """
+        rejects = []
+        for i, column in enumerate(self.score_grid.T):
+            if np.all(column == DISALLOWED):
+                rejects.append(self.roles[i])
+                self.roles[i].no_match = True
+                print(f"No candidate could be found for role {self.roles[i]}")
+        return rejects
+
     @staticmethod
     def _score_or_disqualify(p: Pair) -> Union[DISALLOWED, int]:
         p.score_pair()

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -37,10 +37,14 @@ class BaseClass:
     def __init__(self, uid: str, clearance: str):
         self.uid = uid
         self._clearance = Clearance[clearance]
+        self.paired = False
 
     @property
     def clearance(self) -> Clearance:
         return self._clearance
+
+    def mark_paired(self):
+        self.paired = True
 
 
 class Candidate(BaseClass):
@@ -111,7 +115,7 @@ class Role(BaseClass):
         self.locations = {loc.strip() for loc in location.split(",")}
         self.department = department
         self.priority_role = Priority[priority_role.upper()]
-        self.suitable_year_groups = {
+        self.suitable_year_groups: set[int] = {
             int(year) for year in suitable_for_year_group.split(",")
         }
         self.private_office_role = json.loads(private_office_role.lower())
@@ -122,6 +126,7 @@ class Role(BaseClass):
         self.immigration_role = json.loads(immigration_role.lower())
         self.skill_focus = skill_focus
         self.secondary_focus = secondary_focus
+        self.no_match: bool = False
 
     @property
     def clearance_required(self) -> Clearance:
@@ -129,6 +134,9 @@ class Role(BaseClass):
 
     def from_anywhere(self) -> bool:
         return not {"Available Nationally", "Remote"}.isdisjoint(self.locations)
+
+    def __repr__(self):
+        return self.uid
 
 
 class Pair:

--- a/fast_stream_22/scripts/process_pairs.py
+++ b/fast_stream_22/scripts/process_pairs.py
@@ -1,7 +1,9 @@
+import csv
+from functools import partial
+
 import click
-from fast_stream_22.matching.match import Matching
+from fast_stream_22.matching.match import Process, Bid
 from fast_stream_22.matching.read_in import read_candidates, read_roles
-from numpy import savetxt
 
 
 @click.command
@@ -9,9 +11,27 @@ from numpy import savetxt
     "--candidates", help="Path to candidates file", default="./candidates.csv", type=str
 )
 @click.option("--roles", help="Path to roles file", default="./roles.csv", type=str)
-def process_matches(roles: str, candidates: str):
-    match = Matching(read_candidates(candidates), read_roles(roles))
-    savetxt("grid.csv", match.score_grid, fmt="%s", delimiter=",")
-    matches = match.report_pairs()
-    for pair in matches:
-        print(f"{pair[0]},{pair[1]}")
+@click.option(
+    "--bids", help="Path to file containing bids", default="./bids.csv", type=str
+)
+def process_matches(bids: str, roles: str, candidates: str):
+    return conduct_matching(bids, roles, candidates)
+
+
+def conduct_matching(
+    bid_file: str = "./bids.csv",
+    role_file: str = "./roles.csv",
+    candidate_file: str = "./roles.csv",
+):
+    dept_bids = []
+    with open(bid_file) as bids_file:
+        bids_reader = csv.reader(bids_file)
+        for row in bids_reader:
+            partial_bid = partial(Bid, department=row[0])
+            for cohort, value in enumerate(row[1:]):
+                dept_bids.extend([partial_bid(cohort=cohort + 1, number=int(value))])
+    process_obj = Process(
+        read_candidates(candidate_file), read_roles(role_file), dept_bids
+    )
+    process_obj.compute()
+    return process_obj.pairings

--- a/fast_stream_22/scripts/process_pairs.py
+++ b/fast_stream_22/scripts/process_pairs.py
@@ -15,7 +15,10 @@ from fast_stream_22.matching.read_in import read_candidates, read_roles
     "--bids", help="Path to file containing bids", default="./bids.csv", type=str
 )
 def process_matches(bids: str, roles: str, candidates: str):
-    return conduct_matching(bids, roles, candidates)
+    cohort_pairings = conduct_matching(bids, roles, candidates)
+    for cohort in cohort_pairings.values():
+        for pair in cohort:
+            print(pair[0], pair[1])
 
 
 def conduct_matching(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fast-stream-22"
-version = "0.6.1"
+version = "0.7.0"
 description = ""
 authors = ["jonathan.kerr <jonathan.kerr@digital.cabinet-office.gov.uk>"]
 readme = "README.md"
@@ -19,7 +19,7 @@ pytest = "^7.2.0"
 
 [tool.poetry.group.development.dependencies]
 pre-commit = "^2.20.0"
-bumpversion = "^0.6.1"
+bumpversion = "^0.7.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fast-stream-22"
-version = "0.7.0"
+version = "0.7.1"
 description = ""
 authors = ["jonathan.kerr <jonathan.kerr@digital.cabinet-office.gov.uk>"]
 readme = "README.md"
@@ -19,7 +19,7 @@ pytest = "^7.2.0"
 
 [tool.poetry.group.development.dependencies]
 pre-commit = "^2.20.0"
-bumpversion = "^0.7.0"
+bumpversion = "^0.7.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,32 @@
 import random
 import uuid
+from typing import Literal, TypeVar
 
 import pytest
 
-from fast_stream_22.matching.models import Role, Candidate
+from fast_stream_22.matching.models import Role, Candidate, BaseClass
+
+T = TypeVar("T", bound=BaseClass)
+
+
+@pytest.fixture
+def candidate_factory():
+    def _candidate_factory(kwargs):
+        return object_factory("candidate", kwargs)
+
+    return _candidate_factory
+
+
+@pytest.fixture
+def role_factory():
+    def _role_factory(kwargs):
+        return object_factory("role", kwargs)
+
+    return _role_factory
+
+
+def object_factory(object_type: Literal["candidate", "role"], kwargs) -> T:
+    return {"candidate": Candidate, "role": Role}[object_type](**kwargs)  # type: ignore
 
 
 @pytest.fixture

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,3 +1,7 @@
+from unittest.mock import patch
+
+from munkres import DISALLOWED
+
 from fast_stream_22.matching.match import Matching
 from fast_stream_22.matching.models import Candidate, Role
 
@@ -17,3 +21,11 @@ class TestMatchClass:
         m = Matching(random_candidates, random_roles)
         pairs = m._match()
         assert pairs
+
+    def test_reject_impossible_roles(self, random_candidates, random_roles):
+        with patch(
+            "fast_stream_22.matching.match.Matching._score_or_disqualify",
+            return_value=DISALLOWED,
+        ):
+            m = Matching(random_candidates, random_roles)
+            assert m.reject_impossible_roles() == random_roles

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from fast_stream_22.matching.match import Process, Bid
+from fast_stream_22.matching.models import Candidate, Role
+
+
+class TestProcess:
+    def test_when_bids_full_no_more_roles_from_that_department(self):
+        bids = [Bid(1, "CO", 5)]
+        candidates = [
+            MagicMock(
+                spec=Candidate, **{"uid": f"c-{i}", "paired": False, "year_group": 1}
+            )
+            for i in range(10)
+        ]
+        roles = [
+            MagicMock(
+                spec=Role,
+                **{
+                    "uid": f"r-{i}",
+                    "paired": False,
+                    "suitable_year_groups": {1},
+                    "priority_role": 3,
+                    "department": "CO",
+                },
+            )
+            for i in range(15)
+        ]
+        with patch(
+            "fast_stream_22.matching.match.Process.all_roles", new_callable=PropertyMock
+        ) as mock_get_roles, patch(
+            "fast_stream_22.matching.match.Process.pair_off"
+        ) as mock_pairs:
+            mock_pairs.return_value = [(f"c-{i}", f"r-{i}") for i in range(5)]
+            p = Process(candidates, roles, bids)
+            p.max_rounds = 1
+            mock_get_roles.return_value = roles
+            assert p.match_cohort(1)
+            assert p.bids[0].count == 5
+
+    def test_all_roles_property_sorts_correctly(self, random_roles):
+        p = Process(
+            [
+                MagicMock(
+                    spec=Candidate,
+                    **{"uid": f"c-{i}", "paired": False, "year_group": 1},
+                )
+                for i in range(10)
+            ],
+            random_roles,
+            bids=[Bid(1, "CO", 5)],
+        )
+        all_roles = p.all_roles
+        first = all_roles[0]
+        last = all_roles[-1]
+        assert first.priority_role.value > last.priority_role.value


### PR DESCRIPTION
This is really, really exciting and moves us closer to a version 1.0.0 release 🥳 

## Context
New requirements came to light recently. Specifically, the way this scheme is structured means that:
- departments bid for _x_ number of people from each year group
- they pay for those, and can't afford to have more - so there's a ceiling on how many candidates can be paired with each department
- at the same time, there's a minimum service level that the scheme would like to maintain. Specifically, 80% of bids should be met

## Approach
To meet these requirements, I've created a lot more code. That's unfortunate, but I think necessary. The new `Process` object breaks down all of the roles into roles suitable for each cohort. It then slices these roles according to the maximum number of bids from each department, which means that a department can never be paired with more people than it has bid for.

I've also created a `Bid` object, which contains this data, and keeps track of the minimum service level.

A strange thing came out of testing with real data. Running the algorithm junior to senior - that is, first matching the year 1 cohort, and then year 2, etc - resulted in everyone being paired. This is contrasted with the opposite, senior-junior, where there were a couple of people who couldn't be paired. This is the opposite of the way we do it at the moment, but I can't argue with the outcome