### PR TITLE
Fill min numbers

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.1
+current_version = 0.7.2
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.2
+current_version = 0.7.3
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2022-12-29
+### Changed
+- `Pair` no longer scores the priority of the role. The priority is used to decide in which order to feed roles into
+  the process, but we shouldn't be increasing a role's score just because a department think it's important. Their
+  context is not our context
+
 ## [0.7.1] - 2022-12-23
 ### Changed
 - the script is updated to print its outputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2022-12-29
+### Changed
+- in the first round of matching each cohort, departments may only put forwards 80% of their bids for consideration.
+  This approach ensures that almost everyone gets at least 80% of their required bids. For following rounds,
+  departments put forward (number of bids - number of assigned candidates) bids.
+- this approach unfortunately means that some candidates will not get their most suitable role, because it may be
+  hidden away as a lower priority. However, as this scheme is funded by departments, we must recognise that their
+  priorities come first.
+
 ## [0.7.2] - 2022-12-29
 ### Changed
 - `Pair` no longer scores the priority of the role. The priority is used to decide in which order to feed roles into

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -71,21 +71,18 @@ class Process:
         total_bids = 0
         total_count = 0
         dept_bids_mapping = defaultdict(list)
-        print("bids/count")
         for bid in self.bids:
             dept_bids_mapping[bid.department].append(bid)
             total_bids += bid.number
         all_min_bids = 0
+        print("bids/count")
         for dept, bids in dept_bids_mapping.items():
-            bids_matches = ",".join([f"{bid.number}, {bid.count}" for bid in bids])
-            print(f"{dept}, {bids_matches}")
-            # all_bids = sum([b.number for b in bids])
+            bids_matches = ",".join([f"{bid.number},{bid.count}" for bid in bids])
+            print(f"{dept},{bids_matches}")
             min_bids = sum([b.min_number for b in bids])
             all_min_bids += min_bids
             this_count = sum([b.count for b in bids])
             total_count += this_count
-            # print(f"{dept},{all_bids},{this_count}")
-            # print(f"Department {dept} bid for {all_bids} and received {total_count} or {total_count/all_bids*100}%")
         print(
             f"There were {total_bids} bids in total against {total_count} total"
             " candidates"

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -27,12 +27,16 @@ class Bid:
         return max([int(0.8 * self.number), self.number - 1, 1])
 
 
+Result = tuple[str, str, int]
+
+
 class Process:
     def __init__(
         self,
         all_candidates: Sequence[Candidate],
         all_roles: Sequence[Role],
         bids: Sequence[Bid],
+        senior_to_junior: bool = False,
     ):
         self._all_candidates = all_candidates
         self.candidate_mapping: dict[str, Candidate] = {
@@ -41,17 +45,20 @@ class Process:
         self._all_roles = all_roles
         self.all_roles_mapping: dict[str, Role] = {r.uid: r for r in all_roles}
         self.bids = bids
-        self.pairings: dict[int, list[tuple[str, str]]] = defaultdict(list)
+        self.pairings: dict[int, list[Result]] = defaultdict(list)
         self.max_rounds = 3
+        self.senior_to_junior = senior_to_junior
 
     def compute(self):
         """
-        Try to solve each cohort in turn, starting with the most junior. When finished, unmark any roles that were
-        rejected, as they may be suitable for the next cohort.
+        Try to solve each cohort in turn. The order is defined in self.senior_to_junior. When finished, unmark any roles
+        that were rejected, as they may be suitable for the next cohort.
 
         :return:
         """
-        cohorts = sorted(set((bid.cohort for bid in self.bids)), reverse=False)
+        cohorts = sorted(
+            set((bid.cohort for bid in self.bids)), reverse=self.senior_to_junior
+        )
         for cohort in cohorts:
             if self.match_cohort(cohort):
                 print(f"Successfully matched cohort {cohort}")
@@ -61,22 +68,20 @@ class Process:
         total_bids = 0
         total_count = 0
         dept_bids_mapping = defaultdict(list)
-
+        print("bids/count")
         for bid in self.bids:
             dept_bids_mapping[bid.department].append(bid)
-            print(
-                f"{bid.department} bid for {bid.number} from Cohort {bid.cohort} and"
-                f" was assigned {bid.count}"
-            )
             total_bids += bid.number
         all_min_bids = 0
         for dept, bids in dept_bids_mapping.items():
-            all_bids = sum([b.number for b in bids])
+            bids_matches = ",".join([f"{bid.number}, {bid.count}" for bid in bids])
+            print(f"{dept}, {bids_matches}")
+            # all_bids = sum([b.number for b in bids])
             min_bids = sum([b.min_number for b in bids])
             all_min_bids += min_bids
             this_count = sum([b.count for b in bids])
             total_count += this_count
-            print(f"{dept},{all_bids},{this_count}")
+            # print(f"{dept},{all_bids},{this_count}")
             # print(f"Department {dept} bid for {all_bids} and received {total_count} or {total_count/all_bids*100}%")
         print(
             f"There were {total_bids} bids in total against {total_count} total"
@@ -160,7 +165,9 @@ class Process:
             role for role in self.all_roles if cohort in role.suitable_year_groups
         ]
         shortlisted_roles = []
-        for bid in cohort_bids.values():
+        for bid in sorted(
+            cohort_bids.values(), key=lambda bid: bid.number, reverse=False
+        ):
             shortlisted_roles.extend(
                 [role for role in suitable_roles if role.department == bid.department][
                     : bid.number - bid.count
@@ -170,12 +177,21 @@ class Process:
         if this_round.reject_impossible_roles():
             return self.match_cohort(cohort, round)
         pairs = self.pair_off(candidates, shortlisted_roles)
+        pair_scores: list[Result] = []
         for candidate_id, role_id in pairs:
             self.candidate_mapping[candidate_id].mark_paired()
             role = self.all_roles_mapping[role_id]
             role.mark_paired()
             cohort_bids[role.department].count += 1
-        self.pairings[cohort].extend(pairs)
+            pair_scores.append(
+                (
+                    candidate_id,
+                    role_id,
+                    Pair(self.candidate_mapping[candidate_id], role).score_pair(),
+                )
+            )
+
+        self.pairings[cohort].extend(pair_scores)
         if len(pairs) == len(candidates):
             return True
         else:

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -24,7 +24,10 @@ class Bid:
 
     @property
     def min_number(self):
-        return max([int(0.8 * self.number), self.number - 1, 1])
+        if self.number == 0:
+            return 0
+        else:
+            return max([int(0.8 * self.number), self.number - 1, 1])
 
 
 Result = tuple[str, str, int]
@@ -168,9 +171,13 @@ class Process:
         for bid in sorted(
             cohort_bids.values(), key=lambda bid: bid.number, reverse=False
         ):
+            if round == 0:
+                shortlist_length = bid.min_number
+            else:
+                shortlist_length = bid.number - bid.count
             shortlisted_roles.extend(
                 [role for role in suitable_roles if role.department == bid.department][
-                    : bid.number - bid.count
+                    :shortlist_length
                 ]
             )
         this_round = Matching(candidates, shortlisted_roles)

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -58,6 +58,30 @@ class Process:
             else:
                 print(f"Could not match cohort {cohort}")
             self.reset_roles()
+        total_bids = 0
+        total_count = 0
+        dept_bids_mapping = defaultdict(list)
+
+        for bid in self.bids:
+            dept_bids_mapping[bid.department].append(bid)
+            print(
+                f"{bid.department} bid for {bid.number} from Cohort {bid.cohort} and"
+                f" was assigned {bid.count}"
+            )
+            total_bids += bid.number
+        all_min_bids = 0
+        for dept, bids in dept_bids_mapping.items():
+            all_bids = sum([b.number for b in bids])
+            min_bids = sum([b.min_number for b in bids])
+            all_min_bids += min_bids
+            this_count = sum([b.count for b in bids])
+            total_count += this_count
+            print(f"{dept},{all_bids},{this_count}")
+            # print(f"Department {dept} bid for {all_bids} and received {total_count} or {total_count/all_bids*100}%")
+        print(
+            f"There were {total_bids} bids in total against {total_count} total"
+            " candidates"
+        )
 
     def reset_roles(self):
         """

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -46,6 +46,9 @@ class BaseClass:
     def mark_paired(self):
         self.paired = True
 
+    def __repr__(self):
+        return self.uid
+
 
 class Candidate(BaseClass):
     def __init__(
@@ -134,9 +137,6 @@ class Role(BaseClass):
 
     def from_anywhere(self) -> bool:
         return not {"Available Nationally", "Remote"}.isdisjoint(self.locations)
-
-    def __repr__(self):
-        return self.uid
 
 
 class Pair:

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -146,7 +146,6 @@ class Pair:
         "department": 10,
         "skill": 20,
         "stretch": 10,
-        "priority": 5,
     }
 
     def __init__(self, c: Candidate, r: Role):
@@ -154,8 +153,6 @@ class Pair:
         self.role = r
         self._score: int = 0
         self._disqualified = False
-        if self.role.priority_role:
-            self._score += self.scoring_weights["priority"]
 
     def score_pair(self) -> int:
         self._check_location()
@@ -168,11 +165,7 @@ class Pair:
         self._stretch_check()
         self._check_nationality()
         self._check_passport()
-        self._score_priority()
         return self._score
-
-    def _score_priority(self):
-        self._score += self.scoring_weights["priority"] * self.role.priority_role.value
 
     def _check_location(self):
         if not self.candidate.can_relocate:

--- a/fast_stream_22/scripts/process_pairs.py
+++ b/fast_stream_22/scripts/process_pairs.py
@@ -4,6 +4,7 @@ from functools import partial
 import click
 from fast_stream_22.matching.match import Process, Bid
 from fast_stream_22.matching.read_in import read_candidates, read_roles
+import time
 
 
 @click.command
@@ -15,10 +16,13 @@ from fast_stream_22.matching.read_in import read_candidates, read_roles
     "--bids", help="Path to file containing bids", default="./bids.csv", type=str
 )
 def process_matches(bids: str, roles: str, candidates: str):
+    start = time.time()
     cohort_pairings = conduct_matching(bids, roles, candidates)
     for cohort in cohort_pairings.values():
         for pair in cohort:
             print(pair[0], pair[1])
+    end = time.time()
+    print(f"Task completed in {(end-start)*1000} milliseconds")
 
 
 def conduct_matching(

--- a/fast_stream_22/scripts/process_pairs.py
+++ b/fast_stream_22/scripts/process_pairs.py
@@ -8,6 +8,7 @@ import time
 
 
 @click.command
+@click.option("--senior_first", help="Match seniors first", default=True, type=bool)
 @click.option(
     "--candidates", help="Path to candidates file", default="./candidates.csv", type=str
 )
@@ -15,20 +16,18 @@ import time
 @click.option(
     "--bids", help="Path to file containing bids", default="./bids.csv", type=str
 )
-def process_matches(bids: str, roles: str, candidates: str):
+def process_matches(bids: str, roles: str, candidates: str, senior_first: bool):
     start = time.time()
-    cohort_pairings = conduct_matching(bids, roles, candidates)
+    cohort_pairings = conduct_matching(bids, roles, candidates, senior_first)
     for cohort in cohort_pairings.values():
         for pair in cohort:
-            print(pair[0], pair[1])
+            print(pair[0], pair[1], pair[2])
     end = time.time()
     print(f"Task completed in {(end-start)*1000} milliseconds")
 
 
 def conduct_matching(
-    bid_file: str = "./bids.csv",
-    role_file: str = "./roles.csv",
-    candidate_file: str = "./roles.csv",
+    bid_file: str, role_file: str, candidate_file: str, senior_first: bool
 ):
     dept_bids = []
     with open(bid_file) as bids_file:
@@ -38,7 +37,7 @@ def conduct_matching(
             for cohort, value in enumerate(row[1:]):
                 dept_bids.extend([partial_bid(cohort=cohort + 1, number=int(value))])
     process_obj = Process(
-        read_candidates(candidate_file), read_roles(role_file), dept_bids
+        read_candidates(candidate_file), read_roles(role_file), dept_bids, senior_first
     )
     process_obj.compute()
     return process_obj.pairings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fast-stream-22"
-version = "0.7.1"
+version = "0.7.2"
 description = ""
 authors = ["jonathan.kerr <jonathan.kerr@digital.cabinet-office.gov.uk>"]
 readme = "README.md"
@@ -19,7 +19,7 @@ pytest = "^7.2.0"
 
 [tool.poetry.group.development.dependencies]
 pre-commit = "^2.20.0"
-bumpversion = "^0.7.1"
+bumpversion = "^0.7.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fast-stream-22"
-version = "0.7.2"
+version = "0.7.3"
 description = ""
 authors = ["jonathan.kerr <jonathan.kerr@digital.cabinet-office.gov.uk>"]
 readme = "README.md"
@@ -19,7 +19,7 @@ pytest = "^7.2.0"
 
 [tool.poetry.group.development.dependencies]
 pre-commit = "^2.20.0"
-bumpversion = "^0.7.2"
+bumpversion = "^0.7.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,43 +1,10 @@
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock
 
 from fast_stream_22.matching.match import Process, Bid
-from fast_stream_22.matching.models import Candidate, Role
+from fast_stream_22.matching.models import Candidate
 
 
 class TestProcess:
-    def test_when_bids_full_no_more_roles_from_that_department(self):
-        bids = [Bid(1, "CO", 5)]
-        candidates = [
-            MagicMock(
-                spec=Candidate, **{"uid": f"c-{i}", "paired": False, "year_group": 1}
-            )
-            for i in range(10)
-        ]
-        roles = [
-            MagicMock(
-                spec=Role,
-                **{
-                    "uid": f"r-{i}",
-                    "paired": False,
-                    "suitable_year_groups": {1},
-                    "priority_role": 3,
-                    "department": "CO",
-                },
-            )
-            for i in range(15)
-        ]
-        with patch(
-            "fast_stream_22.matching.match.Process.all_roles", new_callable=PropertyMock
-        ) as mock_get_roles, patch(
-            "fast_stream_22.matching.match.Process.pair_off"
-        ) as mock_pairs:
-            mock_pairs.return_value = [(f"c-{i}", f"r-{i}") for i in range(5)]
-            p = Process(candidates, roles, bids)
-            p.max_rounds = 1
-            mock_get_roles.return_value = roles
-            assert p.match_cohort(1)
-            assert p.bids[0].count == 5
-
     def test_all_roles_property_sorts_correctly(self, random_roles):
         p = Process(
             [

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,11 @@
+from fast_stream_22.scripts.process_pairs import conduct_matching
+
+
+def test_conduct_matching():
+    conduct_matching(
+        "CML/2022-11-21 - CML - BIDS.csv",
+        "CML/2022-11-21 - CML - roles.csv",
+        "CML/2022-11-21 - CML - candidates.csv",
+        senior_first=True,
+    )
+    assert True


### PR DESCRIPTION
These changes improve the parity of how candidates are doled out to departments


Two patches here:

## [0.7.3] - 2022-12-29
### Changed
- in the first round of matching each cohort, departments may only put forwards 80% of their bids for consideration.
  This approach ensures that almost everyone gets at least 80% of their required bids. For following rounds,
  departments put forward (number of bids - number of assigned candidates) bids.
- this approach unfortunately means that some candidates will not get their most suitable role, because it may be
  hidden away as a lower priority. However, as this scheme is funded by departments, we must recognise that their
  priorities come first.

## [0.7.2] - 2022-12-29
### Changed
- `Pair` no longer scores the priority of the role. The priority is used to decide in which order to feed roles into
  the process, but we shouldn't be increasing a role's score just because a department think it's important. Their
  context is not our context