### PR TITLE
"All" skill

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.3
+current_version = 0.7.4
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2022-12-30
+### Changed
+- organisations sometimes offer roles that claim to upskill across all required skill areas. To acknowledge this,
+  those roles are scored once, and reasonably highly. However, to discourage departments simply claiming all roles
+  are like this, they still score lower than a true match.
+
 ## [0.7.3] - 2022-12-29
 ### Changed
 - in the first round of matching each cohort, departments may only put forwards 80% of their bids for consideration.

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -222,12 +222,26 @@ class Pair:
         )
 
     def _score_skill(self):
+        """
+        This scores the skills the candidate against the scores offered by the role. If the department has offered a
+        role that offers "ALL" skills, it scores the top score once. However, this is less that a role would score if
+        both foci matched. This is to discourage departments offering generic roles with "ALL" skills.
+
+        :return:
+        """
         bonus = self.scoring_weights["skill"]
-        for skill in (self.candidate.primary_skill, self.candidate.secondary_skill):
-            for focus in (self.role.skill_focus, self.role.secondary_focus):
-                if skill == focus:
-                    self._score += bonus
-                bonus -= 5
+        foci = [self.role.skill_focus, self.role.secondary_focus]
+        if "ALL" in foci:
+            self._score += bonus
+        else:
+            for focus in foci:
+                for skill in (
+                    self.candidate.primary_skill,
+                    self.candidate.secondary_skill,
+                ):
+                    if focus == skill:
+                        self._score += bonus
+                        bonus -= 5
 
     def _stretch_check(self):
         if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fast-stream-22"
-version = "0.7.3"
+version = "0.7.4"
 description = ""
 authors = ["jonathan.kerr <jonathan.kerr@digital.cabinet-office.gov.uk>"]
 readme = "README.md"
@@ -19,7 +19,7 @@ pytest = "^7.2.0"
 
 [tool.poetry.group.development.dependencies]
 pre-commit = "^2.20.0"
-bumpversion = "^0.7.3"
+bumpversion = "^0.7.4"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## [0.7.4] - 2022-12-30
### Changed
- organisations sometimes offer roles that claim to upskill across all required skill areas. To acknowledge this,
  those roles are scored once, and reasonably highly. However, to discourage departments simply claiming all roles
  are like this, they still score lower than a true match.