### PR TITLE
Disqualify low score

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.3
+current_version = 0.7.4
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- calculating a score for a role that offers "ALL" skills has changed, and now offers X points
+
+## [0.7.4] - 2022-12-30
+### Changed
+- `Pair` now disqualifies scores below 20. This is currently hard-coded but will be altered in a future release
 
 ## [0.7.3] - 2022-12-29
 ### Changed

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -165,6 +165,7 @@ class Pair:
         self._stretch_check()
         self._check_nationality()
         self._check_passport()
+        self._check_score()
         return self._score
 
     def _check_location(self):
@@ -241,6 +242,10 @@ class Pair:
                 self._score += self.scoring_weights["stretch"]
             if self.candidate.wants_line_management and self.role.line_management_role:
                 self._score += self.scoring_weights["stretch"]
+
+    def _check_score(self):
+        if self.score < 20:
+            self.disqualified = True
 
     @property
     def disqualified(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fast-stream-22"
-version = "0.7.3"
+version = "0.7.4"
 description = ""
 authors = ["jonathan.kerr <jonathan.kerr@digital.cabinet-office.gov.uk>"]
 readme = "README.md"
@@ -19,7 +19,7 @@ pytest = "^7.2.0"
 
 [tool.poetry.group.development.dependencies]
 pre-commit = "^2.20.0"
-bumpversion = "^0.7.3"
+bumpversion = "^0.7.4"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## [0.7.4] - 2022-12-30
### Changed
- `Pair` now disqualifies scores below 20. This is currently hard-coded but will be altered in a future release