### PR TITLE
Generalist secondments

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.0
+current_version = 0.12.1
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.1
+current_version = 0.12.2
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.2
+current_version = 0.13.0
 commit = True
 tag = True
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,19 +10,19 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
     -   id: black
         args: [--experimental-string-processing]
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 6.0.0
     hooks:
     -   id: flake8
         args: [--max-line-length=131, --extend-ignore=E203]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v1.0.1
     hooks:
     -   id: mypy
         args: [--no-strict-optional, --ignore-missing-imports, --install-types, --non-interactive]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - calculating a score for a role that offers "ALL" skills has changed, and now offers X points
 
+## [0.12.2]
+### Added
+- support for secondments, which are treated as a cohort
+
+### Changed
+- roles that are suitable for Y2 are assumed to be suitable as secondments (needs verifying with users)
+
+
 ## [0.10.0] - 2023-02-09
 ## Added
 - This adds support for the particulars of scoring the SEFS specialism

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - calculating a score for a role that offers "ALL" skills has changed, and now offers X points
 
+## [0.13.0]
+### Changed
+- the system now shuffles the Candidates and Roles before matching them
+- the script `pairing_script` now takes an optional `iterations` argument. I recommend more than 10 to get a really
+  good spread of results
+-
+### Added
+- the system generates some management information about the best iteration
+
 ## [0.12.2]
 ### Added
 - support for secondments, which are treated as a cohort

--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 This code outlines how to match Fast Streamers with their next role. It is currently in development.
 
+## Background
+The Fast Stream is the UK's [best graduate programme](https://www.highfliers.co.uk/download/2022/awards/The-Times-Graduate-Recruitment-Awards-2022.pdf).
+Every year, hundreds of graduates and in-service candidates join the scheme. Over the course of three years, they
+will experience a wide variety of work: from policy in a ministerial private office to the sharp end of operations
+in a JobCentre. Organising these placements, and pairing people off so that they get the best experience possible,
+is a huge and complex task.
+
+This software serves to automate that process, eliminate bias, and free up staff time. It does this by:
+
+- quantifying, with the service owners, what a 'good' pairing of candidate and role looks like
+- identifying disqualifying factors, such as candidates who cannot relocate
+- forming a grid of every potential pairing's score
+- finding the grid configuration that enables the highest overall score
+
+As a result, there will never be a pairing where a candidate could find a free role they'd be more suited for.
+
+This solution reduces staff time by 99.997%
+
+## Business process
+For this system to work, organisations bid for candidates. They also offer roles for candidates to be put into. For
+the system to process these things effectively there must be some slack in the system - that is, the number of roles
+must be greater than the number of bids, which must be greater than the number of candidates.
+
+> Roles > Bids > Candidates
+
 ## Installation
 Download this software with `git`. You will need [poetry](https://python-poetry.org/docs/) to run it effectively.
 

--- a/fast_stream_22/matching/generalist/models.py
+++ b/fast_stream_22/matching/generalist/models.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from functools import wraps
 from typing import Callable
-from fast_stream_22.matching import BasePair, Candidate, Role
-from fast_stream_22.matching.models import Travel, Clearance, Cohort
+from fast_stream_22.matching.pair import BasePair
+from fast_stream_22.matching.models import Travel, Clearance, Cohort, Candidate, Role
 from fast_stream_22.matching.pair import register_scoring_method, C, R
 
 
@@ -63,7 +63,7 @@ class GeneralistRole(Role):
         self.accessibility = accessibility
         self.anchor = anchor
         if Cohort.Two in self.suitable_year_groups:
-            self.suitable_year_groups.add(Cohort.Secondment)
+            self.suitable_year_groups.add(Cohort.SixMonth)
 
 
 def register_method_called(
@@ -89,7 +89,7 @@ class GeneralistPair(BasePair):
 
     min_score = {
         **BasePair.min_score,
-        Cohort.Secondment: BasePair.min_score[Cohort.Two],
+        Cohort.SixMonth: BasePair.min_score[Cohort.Two],
     }
 
     def __init__(self):

--- a/fast_stream_22/matching/generalist/models.py
+++ b/fast_stream_22/matching/generalist/models.py
@@ -85,10 +85,12 @@ class GeneralistPair(BasePair):
         **BasePair.scoring_weights,
         "anchor": 15,
         "preference": 10,
-        "year_appropriate": 15,
     }
 
-    min_score = {**BasePair.min_score, Cohort.Secondment: 15, Cohort.Three: 25}
+    min_score = {
+        **BasePair.min_score,
+        Cohort.Secondment: BasePair.min_score[Cohort.Two],
+    }
 
     def __init__(self):
         super().__init__()

--- a/fast_stream_22/matching/generalist/models.py
+++ b/fast_stream_22/matching/generalist/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import wraps
 from typing import Callable
 from fast_stream_22.matching import BasePair, Candidate, Role
-from fast_stream_22.matching.models import Travel, Clearance
+from fast_stream_22.matching.models import Travel, Clearance, Cohort
 from fast_stream_22.matching.pair import register_scoring_method, C, R
 
 
@@ -23,7 +23,6 @@ class GeneralistCandidate(Candidate):
         match_pref_2: str = None,
         **kwargs,
     ):
-        self.secondment = False
         kwargs["prior_departments"] = kwargs["prior_departments"].replace(" ", ",")
         super().__init__(**kwargs)
         self.match_preferences = {match_pref_2, match_pref_1}
@@ -54,33 +53,12 @@ class GeneralistCandidate(Candidate):
                 self.prior_departments.discard(department)
 
     @property
-    def year_group(self) -> int:
-        return self._year_group
-
-    @year_group.setter
-    def year_group(self, year_group: str) -> None:
-        if year_group.endswith("m"):
-            self.secondment = True
-            self._year_group = 2
-        else:
-            self._year_group = int(year_group)
-
-    @property
     def clearance(self) -> Clearance:
         return super().clearance if self._clearance != Clearance.DV else Clearance.SC
 
 
 class GeneralistRole(Role):
     def __init__(self, accessibility: str, anchor: str, **kwargs):
-        self.secondment = False
-        self.secondment_only = False
-        if "6m" in kwargs["suitable_for_year_group"]:
-            self.secondment = True
-            if kwargs["suitable_for_year_group"] == "6m":
-                self.secondment_only = True
-        kwargs["suitable_for_year_group"] = kwargs["suitable_for_year_group"].replace(
-            "6m", "2"
-        )
         super().__init__(**kwargs)
         self.accessibility = accessibility
         self.anchor = anchor
@@ -101,19 +79,18 @@ def register_method_called(
 
 
 class GeneralistPair(BasePair):
-    scoring_weights = {**BasePair.scoring_weights, "anchor": 15, "preference": 10}
+    scoring_weights = {
+        **BasePair.scoring_weights,
+        "anchor": 15,
+        "preference": 10,
+        "year_appropriate": 15,
+    }
+
+    min_score = {**BasePair.min_score, Cohort.Secondment: 15, Cohort.Three: 25}
 
     def __init__(self):
         super().__init__()
         self.methods_called = set()
-
-    @register_scoring_method
-    def _check_secondment(
-        self, candidate: GeneralistCandidate, role: GeneralistRole
-    ) -> None:
-        self.disqualified = (candidate.secondment and not role.secondment) or (
-            role.secondment_only and not candidate.secondment
-        )
 
     @register_scoring_method
     def _check_travel(self, c: GeneralistCandidate, r: GeneralistRole) -> None:

--- a/fast_stream_22/matching/generalist/models.py
+++ b/fast_stream_22/matching/generalist/models.py
@@ -62,6 +62,8 @@ class GeneralistRole(Role):
         super().__init__(**kwargs)
         self.accessibility = accessibility
         self.anchor = anchor
+        if Cohort.Two in self.suitable_year_groups:
+            self.suitable_year_groups.add(Cohort.Secondment)
 
 
 def register_method_called(

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -1,22 +1,32 @@
 from __future__ import annotations
 
+import csv
 import dataclasses
 import datetime
 import logging
+import random
 import sys
 from collections import defaultdict
+from copy import deepcopy
+from functools import partial
 from typing import (
     Sequence,
     Union,
     TypeVar,
     Optional,
     Type,
+    Iterable,
+    MutableSequence,
 )
+
 from munkres import DISALLOWED, make_cost_matrix, Munkres, UnsolvableMatrix
 
+from fast_stream_22.matching.generalist.models import GeneralistPair
 from fast_stream_22.matching.models import Candidate, Role, BaseClass, Cohort
 from fast_stream_22.matching.pair import Pair, R, C, P
 import numpy as np
+
+from fast_stream_22.matching.read_in import read_candidates, read_roles
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +63,8 @@ class OutOfRolesException(Exception):
 class Process:
     def __init__(
         self,
-        all_candidates: Sequence[Candidate],
-        all_roles: Sequence[Role],
+        all_candidates: MutableSequence[Candidate],
+        all_roles: MutableSequence[Role],
         bids: Sequence[Bid],
         senior_to_junior: bool = False,
         pair_type: Type[P] = Pair,  # type: ignore
@@ -66,7 +76,7 @@ class Process:
         self._all_roles = all_roles
         self.all_roles_mapping: dict[str, Role] = {r.uid: r for r in all_roles}
         self.bids = bids
-        self.pairings: dict[int, list[Result]] = defaultdict(list)
+        self.pairings: dict[Cohort, list[Result]] = defaultdict(list)
         self.max_rounds = 5
         self.senior_to_junior = senior_to_junior
         self.specialism = pair_type
@@ -157,7 +167,7 @@ class Process:
         return [data_point for data_point in data if not data_point.paired]
 
     def pair_off(
-        self, candidates: Sequence[Candidate], roles: Sequence[Role]
+        self, candidates: MutableSequence[Candidate], roles: MutableSequence[Role]
     ) -> list[tuple[str, str]]:
         """
         Create a round of Matching, compute it, and return the pairs
@@ -250,6 +260,8 @@ class Process:
             role = self.all_roles_mapping[role_id]
             role.mark_paired()
             cohort_bids[role.department].count += 1
+            if cohort_bids[role.department].count > cohort_bids[role.department].number:
+                raise ValueError
             pair_scores.append(
                 (
                     candidate_id,
@@ -273,10 +285,15 @@ class Process:
 
 class Matching:
     def __init__(
-        self, candidates: Sequence[Candidate], roles: Sequence[Role], pair_type: Type[P]
+        self,
+        candidates: MutableSequence[Candidate],
+        roles: MutableSequence[Role],
+        pair_type: Type[P],
     ):
         self.candidates = candidates
         self.roles = roles
+        random.shuffle(self.candidates)
+        random.shuffle(self.roles)
         self.pairs = [
             self._score_or_disqualify(pair_type(), c, r)
             for c in candidates
@@ -334,3 +351,75 @@ class Matching:
     def _convert_pair(self, pair: tuple[int, int]) -> tuple[str, str]:
         candidate, role = pair
         return self.candidates[candidate].uid, self.roles[role].uid
+
+
+@dataclasses.dataclass
+class IterationOutcome:
+    def __init__(
+        self,
+        bids: list[Bid],
+        cohort_outcomes: dict[Cohort, list[Result]],
+        iteration: int,
+        success_bound: float = 0.8,
+    ):
+        self.bids = bids
+        self.outcomes = cohort_outcomes
+        self.success_bound = success_bound
+        self.total_score = sum(
+            pair[2] for cohort in self.outcomes.values() for pair in cohort
+        )
+        self.success_count = 0
+        self.iteration = iteration
+        self.count_success()
+
+    def count_success(self):
+        for bid in self.bids:
+            try:
+                if (bid.count / bid.number) >= self.success_bound:
+                    self.success_count += 1
+            except ZeroDivisionError:
+                pass
+
+
+def conduct_matching(
+    bid_file: str,
+    role_file: str,
+    candidate_file: str,
+    senior_first: bool,
+    specialism: str,
+    iterations: int,
+) -> dict[int, IterationOutcome]:
+    specialisms = {"generalist": GeneralistPair}
+    dept_bids = []
+    with open(bid_file) as bids_file:
+        bids_reader: Iterable[dict[str, str]] = csv.DictReader(bids_file)
+        for row in bids_reader:
+            dept = row.pop("dept")
+            partial_bid = partial(Bid, _department=dept)
+            for cohort, value in row.items():
+                dept_bids.extend(
+                    [partial_bid(cohort=Cohort.factory(cohort), number=int(value))]
+                )
+    pairings = dict()
+    i = 0
+    candidates = read_candidates(candidate_file, specialism)
+    roles = read_roles(role_file, specialism)
+    while i < iterations:
+        c = deepcopy(candidates)
+        r = deepcopy(roles)
+        b = deepcopy(dept_bids)
+        try:
+            process_obj = Process(
+                c,
+                r,
+                b,
+                senior_first,
+                pair_type=specialisms.get(specialism, Pair),
+            )
+            process_obj.compute()
+            iteration = IterationOutcome(b, process_obj.pairings, i)
+            pairings[i] = iteration
+        except (UnsolvableMatrix, OutOfRolesException):
+            logger.warning("Unsolvable error")
+        i += 1
+    return pairings

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
-import functools
 import logging
 import sys
 from collections import defaultdict
@@ -165,9 +164,12 @@ class Process:
         """
         return Matching(candidates, roles, self.specialism).report_pairs()
 
-    @functools.lru_cache
     def _cohort_bids(self, cohort: Cohort) -> dict[str, Bid]:
-        return {bid.department: bid for bid in self.bids if bid.cohort == cohort}
+        return {
+            bid.department: bid
+            for bid in self.bids
+            if bid.cohort == cohort and bid.count < bid.number
+        }
 
     def _prepare_round(
         self, cohort: Cohort, round_number: int
@@ -259,8 +261,8 @@ class Process:
             return True
         else:
             logger.info(
-                f"Round {round_number} failed. {len(candidates) - len(pairs)} still to"
-                f" pair ({[c for c in candidates if not c.paired]}"
+                f"Round {round_number} incomplete. {len(candidates) - len(pairs)} still"
+                f" to pair ({[c for c in candidates if not c.paired]}"
             )
             return self.match_cohort(cohort, round_number + 1)
 

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -213,7 +213,7 @@ class Process:
                 role for role in suitable_roles if role.department == bid.department
             ][:shortlist_length]
             if len(departmental_roles) < shortlist_length:
-                logger.warning(
+                logger.debug(
                     f"Cohort {cohort.name}: {bid.department} bid {bid.number}, offered"
                     f" {len(departmental_roles)} roles"
                 )

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -193,11 +193,15 @@ class Process:
                 shortlist_length = bid.min_number
             else:
                 shortlist_length = bid.number - bid.count
-            shortlisted_roles.extend(
-                [role for role in suitable_roles if role.department == bid.department][
-                    :shortlist_length
-                ]
-            )
+            departmental_roles = [
+                role for role in suitable_roles if role.department == bid.department
+            ][:shortlist_length]
+            if len(departmental_roles) < shortlist_length:
+                logger.warning(
+                    f"Cohort {cohort}: {bid.department} bid {bid.number}, offered"
+                    f" {len(departmental_roles)} roles"
+                )
+            shortlisted_roles.extend(departmental_roles)
         return candidates, shortlisted_roles
 
     def match_cohort(

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -46,6 +46,10 @@ class Bid:
 Result = tuple[str, str, int]
 
 
+class OutOfRolesException(Exception):
+    pass
+
+
 class Process:
     def __init__(
         self,
@@ -228,9 +232,9 @@ class Process:
             )
         candidates, shortlisted_roles = self._prepare_round(cohort, round_number)
         if not shortlisted_roles:
-            raise Exception("No roles left to try!")
+            raise OutOfRolesException("No roles left to try!")
         elif len(candidates) > len(shortlisted_roles) and not round_number == 0:
-            raise Exception(
+            raise OutOfRolesException(
                 f"Cohort {cohort.name} round {round_number}: More candidates"
                 f" ({len(candidates)}) than roles ({len(shortlisted_roles)})"
             )

--- a/fast_stream_22/matching/match.py
+++ b/fast_stream_22/matching/match.py
@@ -227,6 +227,11 @@ class Process:
         candidates, shortlisted_roles = self._prepare_round(cohort, round_number)
         if not shortlisted_roles:
             raise Exception("No roles left to try!")
+        elif len(candidates) > len(shortlisted_roles) and not round_number == 0:
+            raise Exception(
+                f"Cohort {cohort.name} round {round_number}: More candidates"
+                f" ({len(candidates)}) than roles ({len(shortlisted_roles)})"
+            )
         this_round = Matching(candidates, shortlisted_roles, self.specialism)
         if rejects := this_round.reject_impossible_roles():
             logger.info(f"Attempt #{failures}: Failed to find enough roles")

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -88,7 +88,7 @@ class Candidate(BaseClass):
         self.can_relocate = json.loads(can_relocate.lower())
         self.first_preference_location = first_location_preference
         self.second_preference_location = second_location_preference
-        self.year_group = year_group
+        self.year_group = Cohort.factory(year_group)
         self.prior_departments = set(
             map(self._stringify_department, prior_departments.split(","))
         )
@@ -103,14 +103,6 @@ class Candidate(BaseClass):
         self.has_passport = json.loads(has_passport.lower())
         self.last_role_main_skill = last_role_main_skill
         self.last_role_secondary_skill = last_role_secondary_skill
-
-    @property
-    def year_group(self):
-        return self._year_group
-
-    @year_group.setter
-    def year_group(self, year_group: str):
-        self._year_group = int(year_group)
 
 
 class Role(BaseClass):
@@ -146,8 +138,8 @@ class Role(BaseClass):
         self.locations = {loc.strip() for loc in location.split(",")}
         self.department = self._stringify_department(department)
         self.priority_role = Priority[priority_role.upper()]
-        self.suitable_year_groups: set[int] = {
-            int(year) for year in suitable_for_year_group.split(",")
+        self.suitable_year_groups: set[Cohort] = {
+            Cohort.factory(year) for year in suitable_for_year_group.split(",")
         }
         self.private_office_role = json.loads(private_office_role.lower())
         self.line_management_role = json.loads(line_management_role.lower())
@@ -191,3 +183,15 @@ class Travel(IntEnum):
             "None": cls.NO_TRAVEL,
         }
         return mapping[travel]
+
+
+class Cohort(IntEnum):
+    One = 2
+    Two = 3
+    Secondment = 1
+    Three = 4
+
+    @classmethod
+    def factory(cls, cohort_str) -> Self:  # type: ignore
+        mapping = {"1": cls.One, "2": cls.Two, "3": cls.Three, "6m": cls.Secondment}
+        return mapping[cohort_str]

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -186,9 +186,9 @@ class Travel(IntEnum):
 
 
 class Cohort(IntEnum):
-    One = 2
-    Two = 3
-    Secondment = 1
+    One = 1
+    Two = 2
+    Secondment = 3
     Three = 4
 
     @classmethod

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -188,10 +188,10 @@ class Travel(IntEnum):
 class Cohort(IntEnum):
     One = 1
     Two = 2
-    Secondment = 3
+    SixMonth = 3
     Three = 4
 
     @classmethod
     def factory(cls, cohort_str) -> Self:  # type: ignore
-        mapping = {"1": cls.One, "2": cls.Two, "3": cls.Three, "6m": cls.Secondment}
+        mapping = {"1": cls.One, "2": cls.Two, "3": cls.Three, "6m": cls.SixMonth}
         return mapping[cohort_str]

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -1,6 +1,6 @@
 import functools
 from enum import IntEnum
-from typing import Literal, Optional
+from typing import Literal, Optional, Self  # type: ignore
 import json
 
 SkillLevel = Literal[0, 1, 2, 3, 4, 5]

--- a/fast_stream_22/matching/pair.py
+++ b/fast_stream_22/matching/pair.py
@@ -3,8 +3,7 @@ import os
 from functools import wraps
 from typing import Callable, TypeVar, Generic
 
-from fast_stream_22.matching.models import Candidate, Role
-
+from fast_stream_22.matching.models import Candidate, Role, Cohort
 
 P = TypeVar("P", bound="BasePair")
 C = TypeVar("C", bound=Candidate)
@@ -46,7 +45,7 @@ class BasePair(Generic[C, R]):
         "stretch": 10,
         "year_appropriate": 5,
     }
-    min_score: dict[int, int] = {1: 5, 2: 15, 3: 20}
+    min_score: dict[int, int] = {Cohort.One: 5, Cohort.Two: 15, Cohort.Three: 20}
 
     def __init_subclass__(cls, **kwargs):
         cls.scoring_method_names = set()

--- a/fast_stream_22/matching/pair.py
+++ b/fast_stream_22/matching/pair.py
@@ -45,7 +45,7 @@ class BasePair(Generic[C, R]):
         "stretch": 10,
         "year_appropriate": 5,
     }
-    min_score: dict[int, int] = {Cohort.One: 5, Cohort.Two: 15, Cohort.Three: 20}
+    min_score: dict[int, int] = {Cohort.One: 15, Cohort.Two: 20, Cohort.Three: 25}
 
     def __init_subclass__(cls, **kwargs):
         cls.scoring_method_names = set()

--- a/fast_stream_22/matching/read_in.py
+++ b/fast_stream_22/matching/read_in.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import csv
 import functools
-from typing import Sequence, Type, TypeVar, Optional
+from typing import Type, TypeVar, Optional, MutableSequence
 
 from fast_stream_22.matching.SEFS.models import SefsRole, SefsCandidate
 from fast_stream_22.matching.generalist.models import (
@@ -15,7 +15,7 @@ from fast_stream_22.matching.models import Candidate, Role, BaseClass
 @functools.lru_cache
 def read_candidates(
     path_to_csv: str = "./candidates.csv", specialism: str = None
-) -> Sequence[Candidate]:
+) -> MutableSequence[Candidate]:
     specialisms = {
         None: Candidate,
         "SEFS": SefsCandidate,
@@ -27,7 +27,7 @@ def read_candidates(
 @functools.lru_cache
 def read_roles(
     path_to_csv: str = "./roles.csv", specialism: Optional[str] = None
-) -> Sequence[Role]:
+) -> MutableSequence[Role]:
     specialisms = {"SEFS": SefsRole, None: Role, "generalist": GeneralistRole}
     return _read_and_create_objects(path_to_csv, specialisms[specialism])
 

--- a/fast_stream_22/scripts/process_pairs.py
+++ b/fast_stream_22/scripts/process_pairs.py
@@ -30,7 +30,6 @@ def process_matches(
         bids, roles, candidates, senior_first, specialism, iterations
     )
     end = time.time()
-    click.echo(f"Task completed in {(end-start)} seconds")
     for iteration, outcome in cohort_pairings.items():
         for cohort_name, cohort in outcome.outcomes.items():
             for pair in cohort:
@@ -41,6 +40,7 @@ def process_matches(
     best_iteration_by_success_bound = max(
         cohort_pairings.values(), key=lambda outcome: outcome.success_count
     )
+    click.echo(f"Task completed in {(end-start)} seconds")
     click.echo(f"Best iteration by score: {best_iteration_by_score.iteration}")
     click.echo(
         "Best iteration by departments scoring above criteria"

--- a/fast_stream_22/scripts/process_pairs.py
+++ b/fast_stream_22/scripts/process_pairs.py
@@ -1,18 +1,13 @@
-import csv
-from functools import partial
-from typing import Iterable
-
 import click
 
-from fast_stream_22.matching.generalist.models import GeneralistPair
-from fast_stream_22.matching.match import Process, Bid
-from fast_stream_22.matching.models import Cohort
-from fast_stream_22.matching.pair import Pair
-from fast_stream_22.matching.read_in import read_candidates, read_roles
+from fast_stream_22.matching.match import conduct_matching
 import time
 
 
 @click.command
+@click.option(
+    "--iterations", help="The number of iterations to go through", default=10, type=int
+)
 @click.option("--specialism", help="The scheme specialism", default=None, type=str)
 @click.option("--senior_first", help="Match seniors first", default=True, type=bool)
 @click.option(
@@ -23,43 +18,32 @@ import time
     "--bids", help="Path to file containing bids", default="./bids.csv", type=str
 )
 def process_matches(
-    bids: str, roles: str, candidates: str, senior_first: bool, specialism: str
+    bids: str,
+    roles: str,
+    candidates: str,
+    senior_first: bool,
+    specialism: str,
+    iterations: int,
 ):
     start = time.time()
     cohort_pairings = conduct_matching(
-        bids, roles, candidates, senior_first, specialism
+        bids, roles, candidates, senior_first, specialism, iterations
     )
-    for cohort in cohort_pairings.values():
-        for pair in cohort:
-            click.echo(f"{','.join(map(str, pair))}")
     end = time.time()
-    click.echo(f"Task completed in {(end-start)*1000} ms")
-
-
-def conduct_matching(
-    bid_file: str,
-    role_file: str,
-    candidate_file: str,
-    senior_first: bool,
-    specialism: str,
-):
-    specialisms = {"generalist": GeneralistPair}
-    dept_bids = []
-    with open(bid_file) as bids_file:
-        bids_reader: Iterable[dict[str, str]] = csv.DictReader(bids_file)
-        for row in bids_reader:
-            dept = row.pop("dept")
-            partial_bid = partial(Bid, _department=dept)
-            for cohort, value in row.items():
-                dept_bids.extend(
-                    [partial_bid(cohort=Cohort.factory(cohort), number=int(value))]
-                )
-    process_obj = Process(
-        read_candidates(candidate_file, specialism),
-        read_roles(role_file, specialism),
-        dept_bids,
-        senior_first,
-        pair_type=specialisms.get(specialism, Pair),
+    click.echo(f"Task completed in {(end-start)} seconds")
+    for iteration, outcome in cohort_pairings.items():
+        for cohort_name, cohort in outcome.outcomes.items():
+            for pair in cohort:
+                click.echo(f"{iteration},{cohort_name.name},{','.join(map(str, pair))}")
+    best_iteration_by_score = max(
+        cohort_pairings.values(), key=lambda outcome: outcome.total_score
     )
-    process_obj.compute()
-    return process_obj.pairings
+    best_iteration_by_success_bound = max(
+        cohort_pairings.values(), key=lambda outcome: outcome.success_count
+    )
+    click.echo(f"Best iteration by score: {best_iteration_by_score.iteration}")
+    click.echo(
+        "Best iteration by departments scoring above criteria"
+        f" ({best_iteration_by_success_bound.success_count}):"
+        f" {best_iteration_by_success_bound.iteration}"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fast-stream-22"
-version = "0.12.0"
+version = "0.12.1"
 description = ""
 authors = ["jonathan.kerr <jonathan.kerr@digital.cabinet-office.gov.uk>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fast-stream-22"
-version = "0.12.1"
+version = "0.12.2"
 description = ""
 authors = ["jonathan.kerr <jonathan.kerr@digital.cabinet-office.gov.uk>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fast-stream-22"
-version = "0.12.2"
+version = "0.13.0"
 description = ""
 authors = ["jonathan.kerr <jonathan.kerr@digital.cabinet-office.gov.uk>"]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def random_candidate_dict():
         candidate = {
             "uuid": f"C-{uuid.uuid4()}",
             "clearance_held": random.choice(["SC", "DV"]),
-            "year_group": random.choice([i for i in range(1, 5)]),
+            "year_group": random.choice([i for i in range(1, 4)]),
             "can_relocate": True,
             "first_location_preference": random.choice(locations),
             "second_location_preference": random.choice([*locations, None]),
@@ -78,7 +78,7 @@ def random_role_dict():
             "priority_role": random.choice(["High", "Medium", "Low"]),
             "suitable_for_year_group": ",".join(
                 map(
-                    str, random.sample([i for i in range(1, 5)], k=random.randint(1, 4))
+                    str, random.sample([i for i in range(1, 4)], k=random.randint(1, 3))
                 )
             ),
             "private_office_role": False,

--- a/tests/test_generalist/test_candidate.py
+++ b/tests/test_generalist/test_candidate.py
@@ -25,13 +25,6 @@ def generalist_candidate(generalist_candidate_dict):
     return GeneralistCandidate(**generalist_candidate_dict)
 
 
-def test_year_group_ending_m_sets_secondment_flag(generalist_candidate):
-    assert not generalist_candidate.secondment
-    generalist_candidate.year_group = "6m"
-    assert generalist_candidate.secondment
-    assert generalist_candidate.year_group == 2
-
-
 def test_instantiation_from_csv_data():
     with open("tests/test_generalist/test_candidates.csv") as test_file:
         r = csv.DictReader(test_file)

--- a/tests/test_generalist/test_script.py
+++ b/tests/test_generalist/test_script.py
@@ -1,4 +1,4 @@
-from fast_stream_22.scripts.process_pairs import conduct_matching
+from fast_stream_22.matching.match import conduct_matching
 
 
 def test_can_match_generalists_with_csv_data():
@@ -8,4 +8,5 @@ def test_can_match_generalists_with_csv_data():
         candidate_file="tests/test_generalist/test_candidates.csv",
         senior_first=False,
         specialism="generalist",
+        iterations=3,
     )

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from fast_stream_22.scripts.process_pairs import conduct_matching
+from fast_stream_22.matching.match import conduct_matching
 
 
 def test_conduct_matching():
@@ -11,5 +11,6 @@ def test_conduct_matching():
             "CML/2022-11-21 - CML - candidates.csv",
             senior_first=True,
             specialism=None,
+            iterations=1,
         )
         assert True


### PR DESCRIPTION
This change incorporates two minor version updates:

## [0.13.0]
### Changed
- the system now shuffles the Candidates and Roles before matching them
- the script `pairing_script` now takes an optional `iterations` argument. I recommend more than 10 to get a really
  good spread of results

### Added
- the system generates some management information about the best iteration

## [0.12.2]
### Added
- support for secondments, which are treated as a cohort

### Changed
- roles that are suitable for Y2 are assumed to be suitable as secondments (needs verifying with users)
