### PR TITLE
Ensure all six-month candidates are marked as "cannot relocate"

### DIFF
--- a/fast_stream_22/matching/generalist/models.py
+++ b/fast_stream_22/matching/generalist/models.py
@@ -41,6 +41,9 @@ class GeneralistCandidate(Candidate):
         self.travel_requirements: Travel = Travel.factory(travel_requirements)
         self._fix_previous_departments()
 
+        if self.year_group == Cohort.SixMonth:
+            self.can_relocate = False
+
     def _fix_previous_departments(self):
         """
         Scottish and Welsh government are so varied that Candidates can visit them again, so we remove them as a 'prior

--- a/fast_stream_22/matching/models.py
+++ b/fast_stream_22/matching/models.py
@@ -200,7 +200,7 @@ class Travel(IntEnum):
 class Cohort(IntEnum):
     One = 1
     Two = 2
-    SixMonth = 3
+    SixMonth = 5
     Three = 4
 
     @classmethod


### PR DESCRIPTION
This ensures that candidates will not be moved when they are rotated into a six-month placement. To facilitate matching, I've moved around the order in which candidates are matched